### PR TITLE
Remove ceil function for calculating square size

### DIFF
--- a/Chess/BoardView.swift
+++ b/Chess/BoardView.swift
@@ -152,7 +152,7 @@ class BoardView: UIView {
 
     private var squareSize: CGSize {
         let bounds = self.bounds.size
-        return CGSize(width: ceil(bounds.width / 8), height: ceil(frame.height / 8))
+        return CGSize(width: bounds.width / 8, height: bounds.height / 8)
     }
 
     private func frame(x: Int, y: Int, size: CGSize) -> CGRect {


### PR DESCRIPTION
This fixes board being cut off from the right side. It was caused by ceil function for a square. I removed it.
Before:
![Simulator Screen Shot - iPhone 14 Pro - 2024-05-12 at 09 00 19](https://github.com/nicklockwood/Chess/assets/58033343/df1050bd-8d9b-4b3f-a932-3ef372865928)

Now:
![Simulator Screen Shot - iPhone 14 Pro - 2024-05-12 at 08 59 47](https://github.com/nicklockwood/Chess/assets/58033343/65f7c137-bb24-42df-abb3-c6ab1163facd)
